### PR TITLE
fix: Dockerfile 删除 LISTEN_ADDR ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ COPY --from=backend-builder /app/tavily-proxy .
 
 VOLUME /app/data
 ENV DATABASE_PATH=/app/data/proxy.db
-ENV LISTEN_ADDR=:8080
 
 EXPOSE 8080
 


### PR DESCRIPTION
这个环境变量导致在 Render 平台部署报错（能部署，切换页面都会异常提示）